### PR TITLE
Implement status emission after streaming

### DIFF
--- a/tools/run_pipeline_tool.py
+++ b/tools/run_pipeline_tool.py
@@ -80,9 +80,14 @@ async def run_pipeline(
                             continue
                         if __event_emitter__:
                             await __event_emitter__(event)
+                if 200 <= resp.status < 300:
+                    await emitter.emit("Pipeline finished", "success", True)
+                else:
+                    await emitter.emit("Pipeline failed", "error", True)
                 return ""
+
             data = await resp.json(content_type=None)
-            if resp.status >= 200 and resp.status < 300:
+            if 200 <= resp.status < 300:
                 await emitter.emit("Pipeline finished", "success", True)
             else:
                 await emitter.emit("Pipeline failed", "error", True)


### PR DESCRIPTION
## Summary
- update `run_pipeline` to emit success/error events after SSE streaming

## Testing
- `PYTHONPATH=. pytest -k pipelines`

------
https://chatgpt.com/codex/tasks/task_b_685d154ef810832cbe5195ec4c222f79