### PR TITLE
Implement system prompt injection helper

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Ensure repository root is first on sys.path for imports like ``test.util``
+ROOT = Path(__file__).resolve().parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/pipelines/prompt.py
+++ b/pipelines/prompt.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+"""Helpers for generating pipeline prompt snippets."""
+
+from typing import Any, Dict, List
+
+from pipelines.loader import load_manifest
+
+PIPELINE_PROMPT_SNIPPET: str = ""
+
+
+def build_pipeline_prompt(manifest: List[Dict[str, Any]]) -> str:
+    """Return YAML snippet documenting available pipelines."""
+    if not manifest:
+        return ""
+    lines = ["## Available Pipelines"]
+    for entry in manifest:
+        pipe_id = entry.get("id")
+        name = entry.get("name")
+        lines.append(f"- id: {pipe_id}")
+        if name:
+            lines.append(f"  name: {name}")
+        lines.append("  call_via: run_pipeline")
+    return "\n".join(lines)
+
+
+def init_pipeline_prompt() -> None:
+    """Load manifest and prepare pipeline prompt snippet."""
+    global PIPELINE_PROMPT_SNIPPET
+    manifest = load_manifest()
+    PIPELINE_PROMPT_SNIPPET = build_pipeline_prompt(manifest)

--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,1 +1,11 @@
+from __future__ import annotations
 
+"""Test package setup."""
+
+import sys
+from pathlib import Path
+
+# Ensure repository root is on sys.path so imports like ``test.util`` work
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/test/test_pipelines/test_prompt.py
+++ b/test/test_pipelines/test_prompt.py
@@ -1,0 +1,26 @@
+from pipelines import prompt
+from pipelines import loader
+
+
+def test_build_pipeline_prompt():
+    manifest = [
+        {"id": "pipe1", "name": "Pipe One"},
+        {"id": "pipe2"},
+    ]
+    snippet = prompt.build_pipeline_prompt(manifest)
+    expected = (
+        "## Available Pipelines\n"
+        "- id: pipe1\n"
+        "  name: Pipe One\n"
+        "  call_via: run_pipeline\n"
+        "- id: pipe2\n"
+        "  call_via: run_pipeline"
+    )
+    assert snippet == expected
+
+
+def test_init_pipeline_prompt(monkeypatch):
+    manifest = [{"id": "a"}]
+    monkeypatch.setattr(loader, "load_manifest", lambda: manifest)
+    prompt.init_pipeline_prompt()
+    assert prompt.PIPELINE_PROMPT_SNIPPET.startswith("## Available Pipelines")


### PR DESCRIPTION
## Summary
- remove core app modifications and revert startup changes
- add `pipelines.prompt` helper that builds a YAML snippet of available pipelines
- expose global `PIPELINE_PROMPT_SNIPPET` and init routine
- include `conftest.py` and `sitecustomize.py` so tests find local packages
- provide unit tests for the prompt helper

## Testing
- `black conftest.py sitecustomize.py test/__init__.py pipelines/prompt.py test/test_pipelines/test_prompt.py`
- `pytest -k pipelines -q`


------
https://chatgpt.com/codex/tasks/task_b_685d16c29618832cbf5323ed83d3a94d