### PR TITLE
Implement MoveFilePipe

### DIFF
--- a/pipelines/move_file_between_kb.py
+++ b/pipelines/move_file_between_kb.py
@@ -1,18 +1,18 @@
 from __future__ import annotations
 
-import asyncio
-from typing import Callable, Any, Dict, List
+from typing import Any, Callable, Dict, List, Optional
+
+from tools.openwebui_tool import Tools
 
 
 async def run(
     metadata: Dict[str, Any],
     *,
     event_emitter: Callable[[dict], Any] | None = None,
+    user: Optional[dict] = None,
 ) -> Dict[str, Any]:
-    """Move a file from one KB to another.
+    """Move a file from one KB to another using the WebUI API."""
 
-    If required metadata fields are missing, return follow_up instructions.
-    """
     required = ["src_kb_id", "dst_kb_id", "file_id"]
     missing: List[str] = [field for field in required if field not in metadata]
     if missing:
@@ -24,18 +24,34 @@ async def run(
             },
         }
 
-    if event_emitter:
-        await event_emitter({"type": "status", "data": {"status": "running"}})
+    emitter = event_emitter
+    if emitter:
+        await emitter({"type": "status", "data": {"status": "validating"}})
 
-    # Placeholder move logic
-    await asyncio.sleep(0)  # simulate async work
+    tools = Tools()
 
-    if event_emitter:
-        await event_emitter(
-            {"type": "status", "data": {"status": "done", "done": True}}
-        )
+    await tools.add_file_to_knowledge(
+        metadata["dst_kb_id"],
+        metadata["file_id"],
+        __user__=user,
+        __event_emitter__=event_emitter,
+    )
+
+    await tools.remove_file_from_knowledge(
+        metadata["src_kb_id"],
+        metadata["file_id"],
+        __user__=user,
+        __event_emitter__=event_emitter,
+    )
+
+    if emitter:
+        await emitter({"type": "status", "data": {"status": "done", "done": True}})
 
     return {
         "finish_reason": "stop",
-        "content": {"moved": True, "file_id": metadata["file_id"]},
+        "content": {
+            "moved": True,
+            "file_id": metadata["file_id"],
+            "dst_kb_id": metadata["dst_kb_id"],
+        },
     }

--- a/test/test_pipelines/test_move_file_between_kb.py
+++ b/test/test_pipelines/test_move_file_between_kb.py
@@ -1,6 +1,50 @@
 import asyncio
+import json
+import sys
+import types
+
+if "aiohttp" not in sys.modules:
+    aiohttp_stub = types.ModuleType("aiohttp")
+
+    class _DummySession:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+
+        async def request(self, *args, **kwargs):
+            raise RuntimeError("aiohttp stub: network disabled")
+
+    aiohttp_stub.ClientTimeout = lambda *args, **kwargs: None
+    aiohttp_stub.ClientSession = _DummySession
+    sys.modules["aiohttp"] = aiohttp_stub
+
+if "open_webui.utils.auth" not in sys.modules:
+    auth_stub = types.ModuleType("open_webui.utils.auth")
+
+    def _create_token(data):
+        return "stub-token"
+
+    auth_stub.create_token = _create_token
+
+    package_stub = types.ModuleType("open_webui")
+    utils_package = types.ModuleType("open_webui.utils")
+    utils_package.auth = auth_stub
+    package_stub.utils = utils_package
+    sys.modules["open_webui"] = package_stub
+    sys.modules["open_webui.utils"] = utils_package
+    sys.modules["open_webui.utils.auth"] = auth_stub
+
+if "open_webui.env" not in sys.modules:
+    env_stub = types.ModuleType("open_webui.env")
+    env_stub.AIOHTTP_CLIENT_TIMEOUT = None
+    env_stub.AIOHTTP_CLIENT_SESSION_SSL = False
+    utils_package.env = env_stub
+    sys.modules["open_webui.env"] = env_stub
 
 from pipelines import move_file_between_kb as pipe
+from tools import openwebui_tool
 
 
 def test_follow_up_when_missing():
@@ -13,8 +57,24 @@ def test_follow_up_when_missing():
     }
 
 
-def test_success():
+def test_success(monkeypatch):
+    calls = []
+
+    async def fake_add(self, kb_id, file_id, *, __user__=None, __event_emitter__=None):
+        calls.append(("add", kb_id, file_id))
+        return json.dumps({"ok": True})
+
+    async def fake_remove(
+        self, kb_id, file_id, *, __user__=None, __event_emitter__=None
+    ):
+        calls.append(("remove", kb_id, file_id))
+        return json.dumps({"ok": True})
+
+    monkeypatch.setattr(openwebui_tool.Tools, "add_file_to_knowledge", fake_add)
+    monkeypatch.setattr(openwebui_tool.Tools, "remove_file_from_knowledge", fake_remove)
+
     metadata = {"src_kb_id": "a", "dst_kb_id": "b", "file_id": "c"}
     result = asyncio.run(pipe.run(metadata))
     assert result["finish_reason"] == "stop"
     assert result["content"]["moved"] is True
+    assert calls == [("add", "b", "c"), ("remove", "a", "c")]

--- a/tools/openwebui_tool.py
+++ b/tools/openwebui_tool.py
@@ -239,3 +239,51 @@ class Tools:
         else:
             await emitter.emit("Deletion failed", "error", True)
         return json.dumps(data, ensure_ascii=False)
+
+    async def add_file_to_knowledge(
+        self,
+        knowledge_id: str,
+        file_id: str,
+        *,
+        __user__: Optional[dict] = None,
+        __event_emitter__: Optional[Callable[[dict], Any]] = None,
+    ) -> str:
+        """Attach a file to the given knowledge base."""
+        emitter = EventEmitter(__event_emitter__)
+        await emitter.emit("Adding file to knowledge…")
+        url = f"/api/v1/knowledge/{knowledge_id}/file/add"
+        status, data = await self._request(
+            "POST",
+            url,
+            json_body={"file_id": file_id},
+            user=__user__,
+        )
+        if status == 200:
+            await emitter.emit("File added", "success", True)
+        else:
+            await emitter.emit("Failed to add file", "error", True)
+        return json.dumps(data, ensure_ascii=False)
+
+    async def remove_file_from_knowledge(
+        self,
+        knowledge_id: str,
+        file_id: str,
+        *,
+        __user__: Optional[dict] = None,
+        __event_emitter__: Optional[Callable[[dict], Any]] = None,
+    ) -> str:
+        """Detach a file from the given knowledge base."""
+        emitter = EventEmitter(__event_emitter__)
+        await emitter.emit("Removing file from knowledge…")
+        url = f"/api/v1/knowledge/{knowledge_id}/file/remove"
+        status, data = await self._request(
+            "POST",
+            url,
+            json_body={"file_id": file_id},
+            user=__user__,
+        )
+        if status == 200:
+            await emitter.emit("File removed", "success", True)
+        else:
+            await emitter.emit("Failed to remove file", "error", True)
+        return json.dumps(data, ensure_ascii=False)


### PR DESCRIPTION
## Summary
- implement MoveFilePipe using Open WebUI API helpers
- expose functions to add/remove files from knowledges
- test pipeline logic with patched helpers
- stub missing modules in tests so pipeline tests run without aiohttp

## Testing
- `black tools/openwebui_tool.py pipelines/move_file_between_kb.py test/test_pipelines/test_move_file_between_kb.py`
- `pytest -k pipelines -q`

------
https://chatgpt.com/codex/tasks/task_b_685d1d9133cc832c9ff5abd025638783