### PR TITLE
Add run_pipeline usage docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,27 @@ If you are running Open WebUI in an offline environment, you can set the `HF_HUB
 export HF_HUB_OFFLINE=1
 ```
 
+### Running a Pipeline via `run_pipeline`
+
+Open WebUI exposes complex operations through pipelines. You can trigger any
+permitted pipeline from the command line using the `run_pipeline` endpoint of
+your Pipelines service. The example below moves a file between knowledge bases.
+
+```bash
+curl -X POST "$PIPE_URL/run" \
+  -H "Authorization: Bearer $PIPE_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "pipe_id": "move_file_pipe",
+    "metadata": {
+      "src_kb_id": "SOURCE_ID",
+      "dst_kb_id": "DEST_ID",
+      "file_id": "FILE_ID"
+    },
+    "user_prompt": "Move file"
+  }'
+```
+
 ## What's Next? 🌟
 
 Discover upcoming features on our roadmap in the [Open WebUI Documentation](https://docs.openwebui.com/roadmap/).

--- a/tools/prd.md
+++ b/tools/prd.md
@@ -97,6 +97,17 @@ User ──> LLM (function‑calling) ──> run_pipeline Tool
 3. **Long copy** (>30 s)
    Pipeline streams progress tokens (`[#####.....] 50 %`) → Tool proxies → WebUI progress bubble animates.
 
+### 5.1 Example cURL
+
+Call the pipeline server directly using `run_pipeline` parameters:
+
+```bash
+curl -X POST "$PIPE_URL/run" \
+  -H "Authorization: Bearer $PIPE_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"pipe_id":"move_file_pipe","metadata":{"src_kb_id":"123","dst_kb_id":"456","file_id":"abc"}}'
+```
+
 ---
 
 ## 6 · Non‑Goals


### PR DESCRIPTION
## Summary
- document how to trigger pipelines via the `run_pipeline` endpoint in `README.md`
- include curl example in `tools/prd.md`

## Testing
- `pytest -k pipelines`

------
https://chatgpt.com/codex/tasks/task_b_685d23fffc40832cae8d60dd4d408c3c