### PR TITLE
Implement pipeline prompt patching via module

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,20 @@ curl -X POST "$PIPE_URL/run" \
   }'
 ```
 
+### Pipeline Management
+
+Pipeline definitions are stored inside the `pipelines/` directory. Call
+`pipelines.prompt.setup()` during startup to load `pipelines/manifest.json` and
+append the permitted pipelines to the system prompt. To adjust permissions,
+provide an ACL file using the `PIPELINE_ACL_PATH` environment variable:
+
+```bash
+export PIPELINE_ACL_PATH=/path/to/acl.json
+```
+
+Update `pipelines/manifest.json` whenever you add new pipeline components so the
+system prompt stays in sync.
+
 ## What's Next? 🌟
 
 Discover upcoming features on our roadmap in the [Open WebUI Documentation](https://docs.openwebui.com/roadmap/).

--- a/pipelines/prompt.py
+++ b/pipelines/prompt.py
@@ -29,3 +29,26 @@ def init_pipeline_prompt() -> None:
     global PIPELINE_PROMPT_SNIPPET
     manifest = load_manifest()
     PIPELINE_PROMPT_SNIPPET = build_pipeline_prompt(manifest)
+
+
+def patch_payload_injection() -> None:
+    """Monkey patch payload.apply_model_system_prompt_to_body to append snippet."""
+    try:
+        from backend.open_webui.utils import payload as payload_module
+    except Exception:  # pragma: no cover - module not available during docs build
+        return
+
+    original = payload_module.apply_model_system_prompt_to_body
+
+    def wrapped(system, form_data, metadata=None, user=None):
+        if system and PIPELINE_PROMPT_SNIPPET:
+            system = f"{system}\n\n{PIPELINE_PROMPT_SNIPPET}"
+        return original(system, form_data, metadata, user)
+
+    payload_module.apply_model_system_prompt_to_body = wrapped
+
+
+def setup() -> None:
+    """Initialize pipeline prompt and patch payload module."""
+    init_pipeline_prompt()
+    patch_payload_injection()

--- a/test/test_pipelines/test_prompt.py
+++ b/test/test_pipelines/test_prompt.py
@@ -24,3 +24,58 @@ def test_init_pipeline_prompt(monkeypatch):
     monkeypatch.setattr(loader, "load_manifest", lambda: manifest)
     prompt.init_pipeline_prompt()
     assert prompt.PIPELINE_PROMPT_SNIPPET.startswith("## Available Pipelines")
+
+
+def test_patch_payload_injection(monkeypatch):
+    import sys
+    import types
+
+    payload_mod = types.ModuleType("payload")
+
+    def original(system, form_data, metadata=None, user=None):
+        form_data["messages"] = [{"role": "system", "content": system}]
+        return form_data
+
+    payload_mod.apply_model_system_prompt_to_body = original
+    sys.modules["backend.open_webui.utils.payload"] = payload_mod
+
+    import importlib
+
+    importlib.reload(prompt)
+    if "open_webui.utils.task" not in sys.modules:
+        package_stub = types.ModuleType("open_webui")
+        utils_package = types.ModuleType("open_webui.utils")
+        task_package = types.ModuleType("open_webui.utils.task")
+        misc_package = types.ModuleType("open_webui.utils.misc")
+        task_package.prompt_template = lambda t, **k: t
+        task_package.prompt_variables_template = lambda t, v: t
+        misc_package.deep_update = lambda a, b: {**a, **b}
+
+        def add_or_update_system_message(content, messages, append=False):
+            messages.insert(0, {"role": "system", "content": content})
+            return messages
+
+        misc_package.add_or_update_system_message = add_or_update_system_message
+        utils_package.task = task_package
+        utils_package.misc = misc_package
+        utils_package.payload = payload_mod
+        package_stub.utils = utils_package
+        sys.modules["open_webui"] = package_stub
+        sys.modules["open_webui.utils"] = utils_package
+        sys.modules["open_webui.utils.payload"] = payload_mod
+        sys.modules["open_webui.utils.task"] = task_package
+        sys.modules["open_webui.utils.misc"] = misc_package
+        sys.modules["backend.open_webui.utils"] = utils_package
+        sys.modules["backend.open_webui.utils.task"] = task_package
+        sys.modules["backend.open_webui.utils.misc"] = misc_package
+        sys.modules["backend.open_webui.utils.payload"] = payload_mod
+    monkeypatch.setattr(
+        prompt,
+        "PIPELINE_PROMPT_SNIPPET",
+        "## Available Pipelines\n- id: x\n  call_via: run_pipeline",
+    )
+    prompt.patch_payload_injection()
+
+    form = {"messages": []}
+    result = payload_mod.apply_model_system_prompt_to_body("hello", form)
+    assert "Available Pipelines" in result["messages"][0]["content"]


### PR DESCRIPTION
## Summary
- revert backend changes
- add a runtime patch to inject pipeline info in `pipelines.prompt`
- document how to enable pipeline prompt injection
- test the patch with stubbed modules

## Testing
- `pytest -q test/test_pipelines/test_prompt.py`
- `pytest -q test/test_pipelines`

------
https://chatgpt.com/codex/tasks/task_b_685d3b268a3c832c95474482eafd0685