### PR TITLE
Enhance tools with typed payloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,8 @@ system prompt stays in sync.
 ### Tools Overview
 
 Helper modules located in `tools/` provide a thin wrapper around the WebUI API
-and pipelines:
+and pipelines. All HTTP calls are asynchronous via `aiohttp`, and payloads are
+validated with Pydantic models:
 
 - `openwebui_tool.py` &ndash; REST API helper with progress events.
 - `knowledge_tool.py` &ndash; create, list and delete knowledges.

--- a/tools/openwebui_tool.py
+++ b/tools/openwebui_tool.py
@@ -3,6 +3,8 @@ import os
 import json
 from typing import Callable, Any, Optional
 
+from pydantic import BaseModel
+
 # Third party imports
 import aiohttp
 
@@ -17,6 +19,19 @@ from .decorators import deprecated
 API_BASE_URL = os.getenv("WEBUI_API_URL", "http://localhost:8080")
 # JWT used for authenticating against the API.
 API_TOKEN = os.getenv("WEBUI_JWT", "")
+
+
+class KnowledgeCreatePayload(BaseModel):
+    """Payload for creating a knowledge entry."""
+
+    name: str
+    description: str
+
+
+class FileIdPayload(BaseModel):
+    """Payload containing a file ID."""
+
+    file_id: str
 
 
 class EventEmitter:
@@ -72,17 +87,21 @@ class Tools:
         method: str,
         endpoint: str,
         *,
-        json_body: Optional[dict] = None,
+        json_body: BaseModel | dict | None = None,
         user: Optional[dict] = None,
     ) -> tuple[int, dict]:
         async with aiohttp.ClientSession(
             timeout=self.timeout, trust_env=True
         ) as session:
             try:
+                if isinstance(json_body, BaseModel):
+                    payload = json_body.model_dump(exclude_none=True)
+                else:
+                    payload = json_body
                 async with session.request(
                     method,
                     f"{self.base_url}{endpoint}",
-                    json=json_body,
+                    json=payload,
                     headers=self._headers(user),
                     ssl=AIOHTTP_CLIENT_SESSION_SSL,
                 ) as resp:
@@ -106,10 +125,11 @@ class Tools:
     ) -> str:
         emitter = EventEmitter(__event_emitter__)
         await emitter.emit("Creating knowledge entry...")
+        payload = KnowledgeCreatePayload(name=name, description=description)
         status, data = await self._request(
             "POST",
             "/api/v1/knowledge/create",
-            json_body={"name": name, "description": description},
+            json_body=payload,
             user=__user__,
         )
         if status == 200:
@@ -255,10 +275,11 @@ class Tools:
         emitter = EventEmitter(__event_emitter__)
         await emitter.emit("Adding file to knowledge…")
         url = f"/api/v1/knowledge/{knowledge_id}/file/add"
+        payload = FileIdPayload(file_id=file_id)
         status, data = await self._request(
             "POST",
             url,
-            json_body={"file_id": file_id},
+            json_body=payload,
             user=__user__,
         )
         if status == 200:
@@ -279,10 +300,11 @@ class Tools:
         emitter = EventEmitter(__event_emitter__)
         await emitter.emit("Removing file from knowledge…")
         url = f"/api/v1/knowledge/{knowledge_id}/file/remove"
+        payload = FileIdPayload(file_id=file_id)
         status, data = await self._request(
             "POST",
             url,
-            json_body={"file_id": file_id},
+            json_body=payload,
             user=__user__,
         )
         if status == 200:

--- a/tools/prd.md
+++ b/tools/prd.md
@@ -54,6 +54,7 @@ User ──> LLM (function‑calling) ──> run_pipeline Tool
 | **Streaming** | If caller sets `stream=true`, proxy Server‑Sent Events chunk‑for‑chunk. |
 | **Errors** | On non‑2xx, return `{ "error": {code, message} }` and status event “error”. |
 | **Permissions** | `pipe_id` must be present in `allowed_pipelines` resolved for that user (see 4.3). |
+| **Implementation** | Request payloads are validated with `pydantic.BaseModel`. |
 
 ### 4.2 Pipeline contract
 | Field | Must |

--- a/tools/run_pipeline_tool.py
+++ b/tools/run_pipeline_tool.py
@@ -6,6 +6,8 @@ import json
 import os
 from typing import Any, Callable, Optional
 
+from pydantic import BaseModel
+
 import aiohttp
 
 from open_webui.env import AIOHTTP_CLIENT_TIMEOUT, AIOHTTP_CLIENT_SESSION_SSL
@@ -14,6 +16,14 @@ from pipelines.acl import is_pipe_allowed
 
 PIPE_URL = os.getenv("PIPE_URL", "http://localhost:8081")
 PIPE_KEY = os.getenv("PIPE_KEY", "")
+
+
+class PipelineRunPayload(BaseModel):
+    """Payload for calling the pipeline service."""
+
+    pipe_id: str
+    metadata: dict[str, Any]
+    user_prompt: str | None = None
 
 
 class EventEmitter:
@@ -59,7 +69,9 @@ async def run_pipeline(
         "Content-Type": "application/json",
     }
     params = {"stream": "true" if stream else "false"}
-    payload = {"pipe_id": pipe_id, "metadata": metadata, "user_prompt": user_prompt}
+    payload = PipelineRunPayload(
+        pipe_id=pipe_id, metadata=metadata, user_prompt=user_prompt
+    )
 
     async with aiohttp.ClientSession(
         timeout=aiohttp.ClientTimeout(total=AIOHTTP_CLIENT_TIMEOUT)
@@ -68,7 +80,7 @@ async def run_pipeline(
             f"{PIPE_URL}/run",
             headers=headers,
             params=params,
-            json=payload,
+            json=payload.model_dump(exclude_none=True),
             ssl=AIOHTTP_CLIENT_SESSION_SSL,
         ) as resp:
             if stream:


### PR DESCRIPTION
## Summary
- add pydantic BaseModels to represent request payloads
- switch run_pipeline tool to use typed payload
- document that payloads are validated with Pydantic
- mention typed tool payloads and aiohttp in README

## Testing
- `pytest -k pipelines` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_b_685d527cdd84832c91e09d41956914d3